### PR TITLE
fix(moves): fix module declares

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This utility is proposed to be added to the Crossplane CLI in [1.15](https://git
 ## Installing
 
 ```shell
-go install github.com/stevendborrelli/crossplane-migrator@latest
+go install github.com/crossplane-contrib/crossplane-migrator@latest
 ```
 
 ## Example Use

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stevendborrelli/crossplane-migrator
+module github.com/crossplane-contrib/crossplane-migrator
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -20,8 +20,8 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
-	"github.com/stevendborrelli/crossplane-migrator/newdeploymentruntime"
-	"github.com/stevendborrelli/crossplane-migrator/newpipeinecomposition"
+	"github.com/crossplane-contrib/crossplane-migrator/newdeploymentruntime"
+	"github.com/crossplane-contrib/crossplane-migrator/newpipeinecomposition"
 )
 
 var _ = kong.Must(&cli)


### PR DESCRIPTION
fix module declares
```
go install github.com/crossplane-contrib/crossplane-migrator@latest
go: downloading github.com/crossplane-contrib/crossplane-migrator v0.0.0-20231029183403-0303928ad371
go: github.com/crossplane-contrib/crossplane-migrator@latest: github.com/crossplane-contrib/crossplane-migrator@v0.0.0-20231029183403-0303928ad371: parsing go.mod:
	module declares its path as: github.com/stevendborrelli/crossplane-migrator
	        but was required as: github.com/crossplane-contrib/crossplane-migrator
```
