### PR TITLE
add default patch type

### DIFF
--- a/newpipeinecomposition/cmd.go
+++ b/newpipeinecomposition/cmd.go
@@ -96,7 +96,7 @@ func (c *Cmd) Run() error {
 		return errors.Wrap(err, "Error generating new Composition")
 	}
 
-	s := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
+	s := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme, json.SerializerOptions{Yaml: true})
 
 	var output io.Writer
 

--- a/newpipeinecomposition/converter_test.go
+++ b/newpipeinecomposition/converter_test.go
@@ -409,6 +409,18 @@ func TestSetMissingPatchFields(t *testing.T) {
 				},
 			},
 		},
+		"PatchWithoutType": {
+			args: args{
+				v1.Patch{
+					FromFieldPath: &fieldPath,
+					ToFieldPath:   &fieldPath,
+				},
+			},
+			want: v1.Patch{
+				Type:          v1.PatchTypeFromCompositeFieldPath,
+				FromFieldPath: &fieldPath,
+				ToFieldPath:   &fieldPath,
+			}},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
- Add default patch type if not specificied
- sets creation timestamp (which is ignored by k8s api server) so that we don't get errors on apply



Fixes #6 