### PR TITLE
chore(typo): fix newpipeinecomposition package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,6 @@ go build -o crossplane-migrator
 
 ## Known Issues
 
-- The migrator attempts to be as accurate as possible in mapping fields but has not been fully tested. The [ControllerConfig test suite](newdeploymentruntime/converter_test.go) and [Composition test suite](newpipeinecomposition/converter_test.go) attempt to cover all cases.
+- The migrator attempts to be as accurate as possible in mapping fields but has not been fully tested. The [ControllerConfig test suite](newdeploymentruntime/converter_test.go) and [Composition test suite](newpipelinecomposition/converter_test.go) attempt to cover all cases.
 - The generated `DeploymentRuntimeConfig` has the same `Name:` as the ControllerConfig.
   

--- a/main.go
+++ b/main.go
@@ -22,14 +22,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/crossplane-contrib/crossplane-migrator/newdeploymentruntime"
-	"github.com/crossplane-contrib/crossplane-migrator/newpipeinecomposition"
+	"github.com/crossplane-contrib/crossplane-migrator/newpipelinecomposition"
 )
 
 var _ = kong.Must(&cli)
 
 var cli struct {
 	NewDeploymentRuntime   newdeploymentruntime.Cmd  `cmd:"" help:"Convert deprecated ControllerConfigs to DeploymentRuntimeConfigs."`
-	NewPipelineComposition newpipeinecomposition.Cmd `cmd:"" help:"Convert Compositions to Composition Pipelines with function-patch-and-transform."`
+	NewPipelineComposition newpipelinecomposition.Cmd `cmd:"" help:"Convert Compositions to Composition Pipelines with function-patch-and-transform."`
 }
 
 func main() {

--- a/newpipelinecomposition/cmd.go
+++ b/newpipelinecomposition/cmd.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package newpipeinecomposition
+package newpipelinecomposition
 
 import (
 	"io"

--- a/newpipelinecomposition/converter.go
+++ b/newpipelinecomposition/converter.go
@@ -1,4 +1,4 @@
-package newpipeinecomposition
+package newpipelinecomposition
 
 import (
 	"fmt"

--- a/newpipelinecomposition/converter_test.go
+++ b/newpipelinecomposition/converter_test.go
@@ -1,4 +1,4 @@
-package newpipeinecomposition
+package newpipelinecomposition
 
 import (
 	"testing"


### PR DESCRIPTION
just renaming the folder and package `newpipeinecomposition` to `newpipelinecomposition`, it was missing an `l`