### PR TITLE
leave environment in place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 crossplane-migrator
+dist/

--- a/newpipelinecomposition/converter.go
+++ b/newpipelinecomposition/converter.go
@@ -37,12 +37,11 @@ func NewPipelineCompositionFromExisting(c *v1.Composition, functionRefName strin
 	}
 	// Migrate existing input
 	input := &Input{
-		Environment: &v1.EnvironmentConfiguration{},
-		PatchSets:   []v1.PatchSet{},
-		Resources:   []v1.ComposedTemplate{},
+		PatchSets: []v1.PatchSet{},
+		Resources: []v1.ComposedTemplate{},
 	}
 	if c.Spec.Environment != nil {
-		input.Environment = c.Spec.Environment
+		cp.Spec.Environment = c.Spec.Environment
 	}
 	if len(c.Spec.PatchSets) > 0 {
 		input.PatchSets = c.Spec.PatchSets


### PR DESCRIPTION
Keeps `environment` settings at the Composition spec level, not in the `input` for function-patch-and-transform.

Fixes #18 